### PR TITLE
fix(bulk): fix expiry date tooltip always expired

### DIFF
--- a/src/app/bulk-collection/bulk-collection.component.html
+++ b/src/app/bulk-collection/bulk-collection.component.html
@@ -43,7 +43,7 @@
 						[scannedBook]="book"
 					></app-book-detail-modal>
 				</td>
-				<td title="Fristen har utløpt!">
+				<td [title]="deadlineHasPassed(book.deadline) ? 'Fristen har utløpt!' : 'Fristen har ikke utløpt'">
 					<fa-icon
 						*ngIf="deadlineHasPassed(book.deadline)"
 						icon="exclamation-circle"


### PR DESCRIPTION
Previously, the tooltip of the expiry date in bulk collection always said expired, even when that was not the case. It has been fixed in thiscommit to say either expired or not depending on the actual expiry status.

Fixes https://trello.com/c/tq1yOMVE/