### PR TITLE
fix(payment-option): hide dibs when no previous orders

### DIFF
--- a/src/app/payment/payment-method-select/payment-method-select.component.ts
+++ b/src/app/payment/payment-method-select/payment-method-select.component.ts
@@ -86,7 +86,10 @@ export class PaymentMethodSelectComponent implements OnInit {
 			)
 		);
 
-		return originalOrders.every((order) => order.byCustomer);
+		return (
+			originalOrders.length > 0 &&
+			originalOrders.every((order) => order.byCustomer)
+		);
 	}
 
 	public onInputChange() {


### PR DESCRIPTION
Currently, handout orders do _not_ produce a movedFromOrder, and thus
the originalOrderIds array will be empty. Since we just check that every
order is by the customer, this will return true if there are no orders.
Therefore, we have to reject DIBS if there are no previous orders.
