### PR TITLE
fix(order-manager): missing null check

### DIFF
--- a/src/app/order-manager/order-manager-list/order-manager-list.component.ts
+++ b/src/app/order-manager/order-manager-list/order-manager-list.component.ts
@@ -250,7 +250,7 @@ export class OrderManagerListComponent implements OnInit, OnDestroy {
 			})
 		);
 
-		populatedRows.sort((a, b) => a.name.localeCompare(b.name));
+		populatedRows.sort((a, b) => a.name?.localeCompare(b.name));
 		this._databaseExcelService.objectsToExcelFile(populatedRows, "orders");
 		this.fetching = false;
 	}


### PR DESCRIPTION
This should not be neccecary, but since it is possible to order books without registering, we need this check for now. In the future, we want to hinder this
