### PR TITLE
fix(branch): set branch ID on load

### DIFF
--- a/src/app/branch/branch-store.service.ts
+++ b/src/app/branch/branch-store.service.ts
@@ -50,16 +50,14 @@ export class BranchStoreService {
 	}
 
 	private async fetchAndStoreBranchInfo(branchID: string) {
-		this.setBranch({} as Branch);
-		let branch: Branch;
+		this.setBranch({ id: branchID } as Branch);
 		try {
-			branch = await this._branchService.getById(branchID);
+			const branch = await this._branchService.getById(branchID);
+			this.setBranch(branch);
+			this._branchChange$.next(branch);
 		} catch (e) {
 			this._authService.logout();
 		}
-		this._currentBranch = branch;
-		this._branchChange$.next(branch);
-		this.setBranch(branch);
 	}
 
 	public subscribe(func: (branch: Branch) => void): Subscription {


### PR DESCRIPTION
This probably fixes the issue where the branch select would not work on load. The issue was that the branch ID was not available early enough in the init sequence. Therefore, I opted to setting this ID before we have actually fetched the branch details. This flow was quite hacky from start (this.setBranch({}) 🙃), but I think this will resolve our problems for now.
