### PR TITLE
feat(match): display match receive/deliver in order details

### DIFF
--- a/src/app/order/order-detail/order-item-detail-list-item/order-item-detail-list-item.component.html
+++ b/src/app/order/order-detail/order-item-detail-list-item/order-item-detail-list-item.component.html
@@ -76,6 +76,22 @@
 			</small>
 		</div>
 	</div>
+	<div class="row" *ngIf="orderItem.type === 'match-receive'">
+		<div class="col text-secondary">
+			<small
+				><fa-icon [icon]="'exchange-alt'" class="mr-2"></fa-icon>
+				<span>mottatt fra elev</span>
+			</small>
+		</div>
+	</div>
+	<div class="row" *ngIf="orderItem.type === 'match-deliver'">
+		<div class="col text-secondary">
+			<small
+				><fa-icon [icon]="'exchange-alt'" class="mr-2"></fa-icon>
+				<span>overlevert til elev</span>
+			</small>
+		</div>
+	</div>
 	<div
 		class="row justify-content-between text-secondary"
 		*ngIf="


### PR DESCRIPTION
I kinda feel like two different icons would be nice, but not sure which. The most important thing is to actually be able to distinguish the two.

<img width="629" alt="Screenshot 2024-06-25 at 21 11 22" src="https://github.com/boklisten/bl-admin/assets/26925695/a506b9ad-b7c9-4a5b-9cc0-50201c23fe49">
